### PR TITLE
Combine search & typeahead into one endpoint

### DIFF
--- a/app-services/functions/searchPageContents.js
+++ b/app-services/functions/searchPageContents.js
@@ -1,13 +1,67 @@
-async function searchAgg(collection, query, limit, skip) {
-  const agg = [
+async function search_prod({ query = "", limit = 10, skip = 0 }) {
+  const pageContents = context.services
+    .get("mongodb-atlas")
+    .db("site-search")
+    .collection("page-contents");
+  
+  // Atlas Function collections return a Cursor, so we call `.next()` to get the result
+  return (await search(pageContents, { query, limit, skip })).next();
+}
+
+async function search_test({ query = "", limit = 10, skip = 0, __test_collection }) {
+  // for testing purposes
+  if (!__test_collection) {
+    throw new Error(`You must provide an SDK collection in __test_collection`);
+  }
+  if (!query) {
+    query = "flutter open close realm";
+  }
+  
+  // SDK collections return a Promise<Document[]>, so we call `[0]` to get the result
+  return (await search(__test_collection, { query, limit, skip }))[0];
+}
+
+async function search(collection, { query = "", limit = 10, skip = 0 }) {
+  const searchResults = await collection.aggregate([
+    // Search for the provided query string
     {
       $search: {
         index: "site_index",
-        text: {
-          query,
-          path: {
-            wildcard: "*",
-          },
+        compound: {
+          should: [
+            {
+              text: {
+                query,
+                path: {
+                  wildcard: "*",
+                },
+              },
+            },
+            {
+              autocomplete: {
+                query: query,
+                path: "title",
+                tokenOrder: "sequential",
+                fuzzy: {
+                  maxEdits: 1,
+                  prefixLength: 0,
+                  maxExpansions: 50,
+                },
+              },
+            },
+            {
+              autocomplete: {
+                query: query,
+                path: "doc_text",
+                tokenOrder: "any",
+                fuzzy: {
+                  maxEdits: 1,
+                  prefixLength: 0,
+                  maxExpansions: 50,
+                },
+              },
+            },
+          ],
         },
         highlight: {
           path: "doc_text",
@@ -15,36 +69,77 @@ async function searchAgg(collection, query, limit, skip) {
         },
       },
     },
+    // Return a subset of all matches
+    { $skip: skip },
+    { $limit: limit },
+    // Add additional search data (i.e. highlights) to matches
     {
       $project: {
         title: 1,
         doc_text: 1,
+        headings: 1,
         highlights: { $meta: "searchHighlights" },
       },
     },
+    // Return a list of all search results + a list of typeahead completions for the search bar
     {
-      $skip: skip,
+      $facet: {
+        results: [{ $match: {} }],
+        completions: [
+          // completions is a list of "hit" highlights in search relevance order
+          {
+            $unwind: {
+              path: "$highlights",
+              preserveNullAndEmptyArrays: false,
+            },
+          },
+          {
+            $unwind: {
+              path: "$highlights.texts",
+              preserveNullAndEmptyArrays: false,
+            },
+          },
+          {
+            $match: {
+              "highlights.texts.type": "hit",
+            },
+          },
+          {
+            $project: {
+              _id: 1,
+              title: 1,
+              doc_text: 1,
+              last_updated: 1,
+              highlight: "$highlights.texts.value",
+            },
+          },
+          {
+            $group: { _id: "$highlight" },
+          },
+        ],
+      },
     },
     {
-      $limit: limit,
+      $project: {
+        results: "$results",
+        completions: {
+          $reduce: {
+            input: "$completions",
+            initialValue: [],
+            in: {
+              $concatArrays: ["$$value", ["$$this._id"]],
+            },
+          },
+        },
+      },
     },
-  ];
-  const results = await collection.aggregate(agg);
-  return results;
-}
-exports = async function (query, limit = 10, skip = 0) {
-  // for testing purposes
-  if (!query) {
-    query = "flutter open close realm";
-  }
-  const pageContents = context.services
-    .get("mongodb-atlas")
-    .db("site-search")
-    .collection("page-contents");
-  const searchResults = await searchAgg(pageContents, query, limit, skip);
+  ]);
+
   return searchResults;
 };
 
+exports = search_prod;
+
 if (typeof module !== "undefined") {
-  module.exports = { searchAgg };
+  module.exports = { search: search_test };
 }

--- a/app-services/functions/test/unit/searchPageContents.test.js
+++ b/app-services/functions/test/unit/searchPageContents.test.js
@@ -1,5 +1,5 @@
 const Realm = require("realm");
-const { searchAgg } = require("../../searchPageContents");
+const { search } = require("../../searchPageContents");
 
 let collection;
 const appId = "docs-search-cxodi";
@@ -19,9 +19,9 @@ afterAll(async () => {
 });
 
 test("searchAgg returns search results", async () => {
-  const res = await searchAgg(collection, "flutter write data", 10, 0);
-  expect(res.length).toBe(10);
-  const someDoc = res[0];
+  const { results } = await search({ query: "flutter write data", limit: 10, __test_collection: collection });
+  expect(results.length).toBe(10);
+  const someDoc = results[0];
   expect(
     Object.hasOwn(someDoc, "title") &&
       Object.hasOwn(someDoc, "doc_text") &&
@@ -30,14 +30,14 @@ test("searchAgg returns search results", async () => {
 });
 
 test("searchAgg returns expected number of results", async () => {
-  const res5 = await searchAgg(collection, "flutter write data", 5, 0);
-  const res10 = await searchAgg(collection, "flutter write data", 10, 0);
+  const { results: res5 } = await search({ query: "flutter write data", limit: 5, __test_collection: collection });
   expect(res5.length).toBe(5);
+  const { results: res10 } = await search({ query: "flutter write data", limit: 10, __test_collection: collection });
   expect(res10.length).toBe(10);
 });
 
 test("searchAgg paginates results", async () => {
-  const firstTwoRes = await searchAgg(collection, "flutter write data", 2, 0);
-  const secondRes = await searchAgg(collection, "flutter write data", 1, 1);
+  const { results: firstTwoRes } = await search({ query: "flutter write data", limit: 2, skip: 0, __test_collection: collection });
+  const { results: secondRes } = await search({ query: "flutter write data", limit: 1, skip: 1, __test_collection: collection });
   expect(firstTwoRes[1]._id === secondRes[0]._id).toBe(true);
 });

--- a/frontend/search/src/api/API.ts
+++ b/frontend/search/src/api/API.ts
@@ -15,7 +15,7 @@ export class API {
   }
 
   public async searchDocs(query: string) {
-    return await this.user?.functions.searchPageContents(query);
+    return await this.user?.functions.searchPageContents({ query });
   }
 
   private async logInUser() {


### PR DESCRIPTION
Implements https://github.com/mongodben/atlas-static-site-search/issues/5

Notably this changes the function signature to accept an object with named arguments instead of positional arguments.